### PR TITLE
Add PR label workflow to enforce required labels

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,29 @@
+name: "pr-label"
+
+on:
+  pull_request:
+    types: [ opened, labeled, unlabeled, synchronize ]
+    branches: [ main ]
+
+concurrency:
+  group: "pr-label-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+
+  pr-label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+
+    - uses: mheap/github-action-required-labels@v5
+      with:
+        labels: "chore, bug, enhancement, feature, release"
+        mode: exactly
+        count: 1
+        add_comment: true
+        message: "This pull request should not be merged because {{ errorString }} {{ count }} of `{{ provided }}` is required."
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Added a new file `.github/workflows/pr-label.yml`
- Configured the workflow to trigger on pull request events
- Set up concurrency settings for the workflow
- Defined a job named `pr-label` that runs on Ubuntu latest
- Granted necessary permissions for the job to write pull requests
- Added a step that uses the `mheap/github-action-required-labels@v5` action
- Configured the action with required labels, count, and message options
