### PR TITLE
Add CI workflow for building, testing, linting, and artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: "ci"
+
+on:
+  push:
+    branches-ignore: [ main ]
+
+concurrency:
+  group: "ci-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+#region Setup
+
+    - uses: actions/checkout@v3
+
+#endregion
+
+#region Build and test assembly
+
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - run: dotnet restore ${{ vars.SLN_PATH }}
+    - run: dotnet build ${{ vars.SLN_PATH }} --configuration Debug --no-restore
+    - run: dotnet test ${{ vars.SLN_PATH }} --no-restore --verbosity normal
+
+#endregion
+
+#region Lint all XML files
+
+    - uses: tecolicom/actions-use-apt-tools@v1
+      with:
+        tools: libxml2-utils
+    - uses: tj-actions/glob@v17
+      id: glob
+      with:
+        files: "**/*.xml"
+    - run: xmllint --noout ${{ steps.glob.outputs.paths }}
+
+#endregion
+
+#region Upload artifact
+
+    - id: get-short-sha
+      run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: "${{ vars.MOD_NAME }}-${{ steps.get-short-sha.outputs.short_sha }}"
+        path: ${{ vars.ZIP_CONTENTS }}
+
+#endregion


### PR DESCRIPTION
- Add new file `.github/workflows/ci.yml`
- Define workflow name as "ci"
- Trigger on push events excluding the `main` branch
- Set concurrency group as "ci-{branch_name}"
- Enable canceling in-progress jobs
- Create a job named "build" that runs on Ubuntu latest
- Checkout the repository using `actions/checkout@v3`
- Setup .NET 6.0.x using `actions/setup-dotnet@v3`
- Restore, build, and test the solution using dotnet commands
- Lint all XML files using libxml2-utils and xmllint
- Get short SHA of the commit and store it in an output variable
- Upload an artifact with a name based on module name and short SHA