### PR TITLE
Refactor CI workflow to rename "build" job to "ci"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
 
-  build:
+  ci:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
- Rename the "build" job in the CI workflow to "ci" for clarity and consistency.
