### PR TITLE
Fix pull request creation command in CD workflow

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -110,7 +110,7 @@ jobs:
 
 #region Create and merge pull request
     - id: create-pull-request
-      run: gh pr create --title "Release ${{ env.VERSION_STRING }}" --body "${{ steps.update-changelog.outputs.changelog }}" --base "${{ github.event.base_ref }}" --head "release/${{ env.VERSION_STRING }}" --label "release"
+      run: gh pr create --title "Release ${{ env.VERSION_STRING }}" --base "${{ github.event.base_ref }}" --head "release/${{ env.VERSION_STRING }}" --label "release"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Removed the `--body` flag from the `gh pr create` command
- The `--body` flag was causing an error and is not necessary for creating a pull request
- Updated the command to only include required flags: `--title`, `--base`, `--head`, and `--label`
- This change ensures that pull requests are created correctly during the CD process
