### PR TITLE
Fix CD workflow to handle cases where there is no previous tag

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -30,7 +30,7 @@ jobs:
     - run: echo "VERSION_STRING=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
     - run: |
-        PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^)
+        PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^) || PREVIOUS_TAG=$(git rev-list --max-parents=0 HEAD)
         echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> $GITHUB_ENV
 #endregion
 


### PR DESCRIPTION
- Update CD workflow to handle cases where there is no previous tag
- Use `git rev-list --max-parents=0 HEAD` as fallback when `git describe` fails
- This should return the SHA of the very first commit to the repository
